### PR TITLE
Fix Issue #7

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,4 @@
+-   Fix an issue due to a fault in write(filename::String, image::HdrImage; endianness = my_endian)[#8](https://github.com/baronauta/RayTracer/pull/8)
 -   Fix an issue with the vertical order of the images [#5](https://github.com/baronauta/RayTracer/pull/5)
 
 # Version 0.1.0

--- a/src/io.jl
+++ b/src/io.jl
@@ -112,7 +112,7 @@ Writes an HDR image to a file in the specified endianness.
 function Base.write(filename::String, image::HdrImage; endianness = my_endian)
     check_extension(filename)
     open(filename, "w") do io
-        write(io, image, endianness)
+        write(io, image; endianness)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,8 +90,7 @@ include("helper.jl")
     
     # writing PNG image on file
     write("test.PFM", img)
-    @test img == read_pfm_image(open("test.PFM"), "r")
-    rm("test.PFM")
+    @test read("test.PFM") == read("reference_le.pfm")
  end
  
  @testset "ToneMapping" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,11 @@ include("helper.jl")
     write(buf, img, endianness = 1.0)
     contents = take!(buf)
     @test contents == BE_REFERENCE_BYTES
+    
+    # writing PNG image on file
+    write("test.PFM", img)
+    @test img == read_pfm_image(open("test.PFM"), "r")
+    rm("test.PFM")
  end
  
  @testset "ToneMapping" begin


### PR DESCRIPTION
# Description
This PR is meant to resolve the error in issue #7. 
A `MethodError` occurs when running 
```
julia demo
```
 to generate and save a `.PFM` image. 

## To do List
- [x] add a test for higlighting this bug into runtest.jl
- [x] search and fix the bug
- [x] update the HISTORY.md 

## The Fault (personal consideration)
It is possible that the failure is caused by passing the `endianness` parameter as a positional argument instead of as a keyword
in file `io.jl` line 115: 
 ```julia
112   function Base.write(filename::String, image::HdrImage; endianness = my_endian)
113       check_extension(filename)
114       open(filename, "w") do io
115            write(io, image, endianness)
116       end
117   end
```
which prevented dispatch to the correct  method of
```julia
write(io::IO, image::HdrImage; endianness)
```  
**Verification**  
-  passes all tests  
- `demo` produces the four expected files without error 