### PR TITLE
Implement Point-light Tracer Renderer

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -175,3 +175,23 @@ function my_renderer(
         )
     )
 end
+
+
+"""
+    pointlight_tracer(
+    world::World,
+    ray::Ray,
+    pcg::PCG;
+    bkg_color = BLACK,
+    )
+
+TBW
+"""
+function pointlight_tracer(
+    world::World,
+    ray::Ray,
+    pcg::PCG;
+    bkg_color = BLACK,
+    )
+    #...
+end


### PR DESCRIPTION
Implement classic point light tracer renderer.

This tracer assumes that non-luminous objects do not contribute to the image brightness. An optional ambient term may be used to partially illuminate shadowed areas, simulating indirect lighting.

The algorithm evaluates light contribution only from luminous sources, reducing the complexity of the rendering equation and enabling faster computations. 
When a ray interacts with a surface, it is determined which LightSource objects are visible and their contribution modulated by the BRDF is summed.

This model is effective in scenes where illumination is dominated by a few small, bright sources (e.g., lamps or the sun).