### PR TITLE
Resolve aspect_ratio conflict between CLI input and scene parsing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
   - `demo` is now limited to the `demo_scene.txt` file in `example/` folder
   - `pfm2image` functionality is now available under `julia RayTracer tonemapping`
 ---
+- Prevent redefinition of `_aspect_ratio` in scene files; external variables now take priority with warning on override [#25](https://github.com/baronauta/RayTracer/pull/25)
 - Added `image2pfm` to generate `.pfm` images from standard LDR formats (see this [commit](https://github.com/baronauta/RayTracer/commit/b99578f2e9ab31780a45ddaefe77ad86a6965c45)).
 - Introduced a modern, extensible CLI using Comonicon.jl [#16](https://github.com/baronauta/RayTracer/pull/16)
 - Added support for custom text-based scene descriptions [#16](https://github.com/baronauta/RayTracer/pull/16)

--- a/RayTracer
+++ b/RayTracer
@@ -77,7 +77,7 @@ Comonicon.@cast function pathtracer(
     height; 
     output_name::String="",
     extension::String = "", # useful fix-it although without output name (so timestamp.extension)
-    angle::Float64=0.0,
+    angle::Union{Float64, Nothing}=nothing,
     n_rays::Int=5,
     max_depth::Int=5,
     russian_roulette_limit::Int=3,
@@ -101,15 +101,18 @@ Comonicon.@cast function pathtracer(
         img_height = parse(Int, height)
         # check if there are variables passed from outside (e.g. angle, calculate aspect_ratio)
         aspect_ratio = img_width/img_height
-        variables = Dict(
-            "angle" => angle,
-            "aspect_ratio" => aspect_ratio,
-            )
+        if !isnothing(angle)
+            external_variables = Dict(
+                "angle" => angle,
+                )
+        else
+            external_variables = Dict{String, Float64}()
+        end
 
         # Parse the scene from text file
         scene = open(scene_file, "r") do io
             instream = RayTracer.InputStream(io, scene_file)
-            RayTracer.parse_scene(instream; variables)
+            RayTracer.parse_scene(instream, aspect_ratio; external_variables)
         end
         println("✓ Scene parsing completed.")
 
@@ -203,7 +206,7 @@ Comonicon.@cast function flattracer(
     height; 
     output_name::String="",
     extension::String = "",
-    angle::Float64=0.0,
+    angle::Union{Float64, Nothing}=nothing,
     )
 
     try
@@ -224,15 +227,18 @@ Comonicon.@cast function flattracer(
         img_height = parse(Int, height)
         # check if there are variables passed from outside (e.g. angle, calculate aspect_ratio)
         aspect_ratio = img_width/img_height
-        variables = Dict(
-            "angle" => angle,
-            "aspect_ratio" => aspect_ratio,
-            )
+        if !isnothing(angle)
+            external_variables = Dict(
+                "angle" => angle,
+                )
+        else
+            external_variables = Dict{String, Float64}()
+        end
 
         # Parse the scene from text file
         scene = open(scene_file, "r") do io
             instream = RayTracer.InputStream(io, scene_file)
-            RayTracer.parse_scene(instream; variables)
+            RayTracer.parse_scene(instream, aspect_ratio; external_variables)
         end
         println("✓ Scene parsing completed.")
 
@@ -318,7 +324,7 @@ Comonicon.@cast function onofftracer(
     height; 
     output_name::String="",
     extension::String = "",
-    angle::Float64=0.0,
+    angle::Union{Float64, Nothing}=nothing,
     )
 
     try
@@ -339,15 +345,18 @@ Comonicon.@cast function onofftracer(
         img_height = parse(Int, height)
         # check if there are variables passed from outside (e.g. angle, calculate aspect_ratio)
         aspect_ratio = img_width/img_height
-        variables = Dict(
-            "angle" => angle,
-            "aspect_ratio" => aspect_ratio,
-            )
+        if !isnothing(angle)
+            external_variables = Dict(
+                "angle" => angle,
+                )
+        else
+            external_variables = Dict{String, Float64}()
+        end
 
         # Parse the scene from text file
         scene = open(scene_file, "r") do io
             instream = RayTracer.InputStream(io, scene_file)
-            RayTracer.parse_scene(instream; variables)
+            RayTracer.parse_scene(instream, aspect_ratio; external_variables)
         end
         println("✓ Scene parsing completed.")
 

--- a/examples/demo_scene.txt
+++ b/examples/demo_scene.txt
@@ -1,27 +1,3 @@
-# Comments start with #
-
-# Scene file format guide: ---------------------------------------------------------------------
-
-# 1. Float variables:
-#    - You can define float variables.
-#    - Variables defined here can be overridden by external float variables; otherwise, their value is used.
-#    - Variables defined in the file can only be defined once.
-#
-# 1.1 NOTE: <angle> can be defined here and also passed externally (basic change of view around z-axis).
-#           <aspect_ratio> is passed externally to avoid distorsion (not necessary to be defined here).
-#
-# 2. Materials:
-#    - You can declare named materials and use them later.
-#
-# 3. Cannot declare named general variables; use them directly instead.
-#    - You cannot create named Transformations, Spheres, Planes, Colors, vectors, etc.
-#
-# 4. Camera:
-#    - Only one camera can be defined.
-#
-# Follow this structure to create valid scene files.
-#------------------------------------------------------------------------------------------------
-
 # Float Variables
 float angle(0.0)
 
@@ -45,4 +21,4 @@ plane(plane_material, identity)
 
 
 # Camera definition
-camera(perspective, rotation_z(angle) * translation([-3, 0, 1]), aspect_ratio, 1.0)
+camera(perspective, rotation_z(angle) * translation([-3, 0, 1]), 1.0)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -71,6 +71,17 @@ struct GeometryError <: CustomException
     msg::String
 end
 
+# --- Warning ---
+"Print a warning message to the standard output in yellow text."
+function print_warning(msg)
+    yellow_bold = Crayons.Crayon(foreground=:yellow, bold=true)
+    yellow = Crayons.Crayon(foreground=:yellow, bold=false)
+    
+    print(yellow_bold("Warning: "))
+    println(yellow(msg))
+end
+
+
 # ─────────────────────────────────────────────────────────────
 # NAME CREATION HELPER FUNCTIONS
 # ─────────────────────────────────────────────────────────────

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -45,13 +45,14 @@ A container representing a scene parsed from a scene description file.
   so it is initially set to `nothing`.
 """
 mutable struct Scene
-    materials::Dict{String,Material}
+    materials::Dict{String, Material}
     world::World
-    camera::Union{Camera,Nothing}
-    float_variables::Dict{String,AbstractFloat}
+    camera::Union{Camera, Nothing}
+    float_variables::Dict{String, AbstractFloat}
 end
 
 """
+    Scene(aspect_ratio)
 Create a default, empty `Scene` instance.
 
 # Description
@@ -60,13 +61,12 @@ Initializes a `Scene` with:
 - an empty dictionary of named `Material`s,
 - a new empty `World`,
 - no camera (`nothing`),
-- an empty dictionary for float variables (`Dict{String, Float64}()`),
-
-# Returns
-A `Scene` object with default empty fields, ready to be populated.
+- an dictionary for float variables containing the key "_aspect_ratio"; underscore to denote that is
+meant to be private, use of this identifier by user is discouraged,
 """
-function Scene()
-    Scene(Dict{String,Material}(), World(), nothing, Dict{String,Float64}())
+function Scene(aspect_ratio::AbstractFloat)
+    float_variables = Dict{String, AbstractFloat}( "_aspect_ratio" => aspect_ratio)
+    Scene(Dict{String,Material}(), World(), nothing, float_variables)
 end
 
 
@@ -394,22 +394,21 @@ end
 """
 Parse a camera:
 
-- `camera(perspective, transformation, aspect_ratio, distance)`
-- `camera(orthogonal, transformation, aspect_ratio)`
+- `camera(perspective, transformation, screen_distance)`
+- `camera(orthogonal, transformation)`
 
 Returns a camera object.
 """
 function parse_camera(instream::InputStream, scene::Scene)
+    aspect_ratio = scene.float_variables["_aspect_ratio"]
     expect_symbol(instream, "(")
     cam = expect_keywords(instream, [PERSPECTIVE, ORTHOGONAL])
     expect_symbol(instream, ",")
     transformation = parse_transformation(instream, scene)
-    expect_symbol(instream, ",")
-    aspect_ratio = expect_number(instream, scene)
     if cam == PERSPECTIVE
         expect_symbol(instream, ",")
-        distance = expect_number(instream, scene)
-        camera = PerspectiveCamera(distance, aspect_ratio, transformation)
+        screen_distance = expect_number(instream, scene)
+        camera = PerspectiveCamera(screen_distance, aspect_ratio, transformation)
     else
         camera = OrthogonalCamera(aspect_ratio, transformation)
     end
@@ -431,26 +430,25 @@ Parses a scene description from the given input stream and constructs a `Scene` 
   - Variables defined internally inside the scene file can only be defined once.
   - Redefinition of an internal variable in the scene file results in a parse error.
 - Only one camera definition is allowed; attempts to define multiple cameras raise an error.
-
-# Returns
-- A `Scene` object representing the parsed scene.
-
-# Throws
-- `GrammarError` if the input contains syntax errors, redefinitions, or unexpected tokens.
 """
-function parse_scene(instream::InputStream; variables = Dict{String,AbstractFloat}())
+function parse_scene(instream::InputStream, aspect_ratio::AbstractFloat; external_variables=Dict{String, AbstractFloat}())
     # This function parses scene.txt and builds the world to render.
-    # Some variables can be defined externally (e.g., via CLI) and others directly inside scene.txt
+    # Some variables can be defined externally (e.g., via CLI) and others directly inside scene.txt.
     #
     # Variable resolution rules:
-    # - If a variable is defined externally and redefined in scene.txt, the external value is kept.
+    # - If a variable is defined externally and redefined in scene.txt, 
+    #   the external value is kept and a warning is thrown.
     # - If a variable is not defined externally, it can be defined once inside scene.txt.
-    # - If an internal variable is redefined later in the file, that is an error.
+    # - If an internal variable is redefined later in the file, it is an GrammarError.
 
-    scene = Scene()
+    scene = Scene(aspect_ratio)
 
-    # Copy external variables into the scene
-    scene.float_variables = deepcopy(variables)
+    if haskey(external_variables, "_aspect_ratio")
+        print_warning("redefinition of \"_aspect_ratio\" is discouraged")
+    end
+
+    # # Copy external variables into scene.float_variables
+    # scene.float_variables = deepcopy(external_variables)
 
     while true
 
@@ -459,24 +457,38 @@ function parse_scene(instream::InputStream; variables = Dict{String,AbstractFloa
         # End of file
         isnothing(token) && break
 
-
-        # The first token of each construct must be a keyword, either a definition of var or a creation of object
-        #       (e.g., FLOAT, MATERIAL, SPHERE, etc.)
-        # Note: using 'expect_keywords' would require first read the token and check if reached end of file, 
-        #       then unread_token and then use expect_keywords; this is simpler and clearer:
+        # The first token of each construct must be a keyword
         if !(isa(token, KeywordToken))
             throw(GrammarError(token.location, "expected a keyword instead of $token"))
         end
 
         if token.keyword == FLOAT
-            # memorize token name and value
             var_name = expect_identifier(instream)
             var_loc = instream.location
             expect_symbol(instream, "(")
             var_val = expect_number(instream, scene)
             expect_symbol(instream, ")")
 
-            # Handle other recognized keywords
+            if haskey(external_variables, var_name)
+                # Variable already defined in external_variables:
+                #   - Keep the value in external_variables, 
+                #     copy it into scene.float_variables to make it available in Scene
+                #   - Throw a warning
+                print_warning("variable \"$var_name\" at $var_loc conflicts with an external definition — using the external value")
+                scene.float_variables[var_name] = external_variables[var_name]
+
+            elseif haskey(scene.float_variables, var_name)
+                # Variable already stored in scene.float_variables:
+                #   - Throw a GrammarError
+                throw(GrammarError(var_loc, "variable $var_name cannot be redefined"))
+                
+            else
+                # No conflicts! It is a new variable
+                scene.float_variables[var_name] = var_val
+            end
+            
+        # Handle other recognized keywords
+
         elseif token.keyword == MATERIAL
             material_name, material = parse_material(instream, scene)
             scene.materials[material_name] = material

--- a/test/parser_tests.jl
+++ b/test/parser_tests.jl
@@ -29,15 +29,20 @@
 
         sphere(sphere_material, translation([0, 0, 1]))
 
-        camera(perspective, rotation_z(30) * translation([-4, 0, 1]), 1.0, 2.0)
+        camera(perspective, rotation_z(30) * translation([-4, 0, 1]), 2.0)
         """
     )
 
+    aspect_ratio = 1.
     instream = RayTracer.InputStream(stream, "test")
-    scene = RayTracer.parse_scene(instream)
+    scene = RayTracer.parse_scene(instream, aspect_ratio)
+
+    # Check that aspect_ratio is correctly stored in scene.float_variables
+    @test haskey(scene.float_variables, "_aspect_ratio")
+    @test scene.float_variables["_aspect_ratio"] == aspect_ratio
 
     # Check that `float clock(150)` is stored in scene.float_variables
-    @test length(scene.float_variables) == 1
+    @test length(scene.float_variables) == 2   # _aspect_ratio and clock
     @test haskey(scene.float_variables, "clock")
     @test scene.float_variables["clock"] == 150.0
 
@@ -85,7 +90,7 @@
     # Check camera
     @test isa(scene.camera, PerspectiveCamera)
     @test scene.camera.transformation ≈ rotation_z(30) * translation(Vec(-4., 0., 1.))
-    @test scene.camera.aspect_ratio ≈ 1.0
+    @test scene.camera.aspect_ratio ≈ aspect_ratio    # Parsed from scene.float_variables["_aspect_ratio"]
     @test scene.camera.distance ≈ 2.0
 end
 
@@ -100,7 +105,7 @@ end
 
         err_thrown = false
         try
-            _ = RayTracer.parse_scene(instream)
+            _ = RayTracer.parse_scene(instream, 1.0)
         catch e
             if isa(e, GrammarError)
                 err_thrown = true
@@ -130,7 +135,7 @@ end
 
         err_thrown = false
         try
-            _ = RayTracer.parse_scene(instream)
+            _ = RayTracer.parse_scene(instream, 1.0)
         catch e
             if isa(e, GrammarError)
                 err_thrown = true
@@ -144,8 +149,8 @@ end
     @testset "Double camera" begin
         stream = IOBuffer(
             """
-            camera(perspective, rotation_z(30) * translation([-4, 0, 1]), 1.0, 1.0)
-            camera(orthogonal, identity, 1.0, 1.0)
+            camera(perspective, rotation_z(30) * translation([-4, 0, 1]), 1.0)
+            camera(orthogonal, identity, 1.0)
             """
         )
 
@@ -153,7 +158,7 @@ end
 
         err_thrown = false
         try
-            _ = RayTracer.parse_scene(instream)
+            _ = RayTracer.parse_scene(instream, 1.0)
         catch e
             if isa(e, GrammarError)
                 err_thrown = true
@@ -168,7 +173,7 @@ end
 
         stream = IOBuffer(
             """
-            camera(rullo, rotation_z(30) * translation([-4, 0, 1]), 1.0, 1.0)
+            camera(rullo, rotation_z(30) * translation([-4, 0, 1]), 1.0)
             """
         )
 
@@ -176,7 +181,7 @@ end
 
         err_thrown = false
         try
-            _ = RayTracer.parse_scene(instream)
+            _ = RayTracer.parse_scene(instream, 1.0)
         catch e
             if isa(e, GrammarError)
                 err_thrown = true
@@ -191,7 +196,7 @@ end
 
         stream = IOBuffer(
             """
-            camera(identity, rotation_z(30) * translation([-4, 0, 1]), 1.0, 1.0)
+            camera(identity, rotation_z(30) * translation([-4, 0, 1]), 1.0)
             """
         )
 
@@ -199,7 +204,7 @@ end
 
         err_thrown = false
         try
-            _ = RayTracer.parse_scene(instream)
+            _ = RayTracer.parse_scene(instream, 1.0)
         catch e
             if isa(e, GrammarError)
                 err_thrown = true
@@ -209,6 +214,4 @@ end
         end
         @test err_thrown
     end
-
-
 end


### PR DESCRIPTION
This PR resolves an inconsistency between the text-based scene parsing and the CLI-provided input. Specifically, the issue stems from the fact that users are always required to provide the image` width` and `height` via CLI — from which a proper `aspect_ratio` should be computed. Allowing `aspect_ratio` to also be defined in the scene file in the definition of `camera` introduces redundancy and potential conflict.

## Changes
- Added `_aspect_ratio` as a default entry in `Scene.float_variables`, computed from the CLI input.

- Removed support for redefining `_aspect_ratio` in the scene file to avoid ambiguity. If the user intentionally wants to override it, they must explicitly write: ` float _aspect_ratio(<new_val>)`.
The leading underscore (`_`) in the variable name is meant to discourage accidental redefinition and signal that it is a reserved/internal parameter.

- Simplified handling of `external_variables` in `parse_scene`: external variables now cleanly override internally defined ones. A warning message is printed whenever such an override occurs, improving transparency.